### PR TITLE
Fix for latest CFW platform update with Blob/File support

### DIFF
--- a/example/polyfill/package.json
+++ b/example/polyfill/package.json
@@ -6,7 +6,6 @@
   },
   "devDependencies": {
     "@ssttevee/cfw-formdata-polyfill": "^0.1.0",
-    "@ssttevee/blob-ponyfill": "^0.1.0",
     "rollup": "^1.20.3",
     "rollup-plugin-inject": "^3.0.1",
     "rollup-plugin-node-resolve": "^5.2.0"

--- a/example/polyfill/rollup.config.js
+++ b/example/polyfill/rollup.config.js
@@ -10,12 +10,5 @@ module.exports = {
     plugins: [
         /* remove this */ { resolveId: (source) => source === '@ssttevee/cfw-formdata-polyfill' ? { id: require.resolve('../../index.js') } : undefined },
         resolve(),
-        inject({
-            modules: {
-                Blob: '@ssttevee/blob-ponyfill/blob',
-                File: '@ssttevee/blob-ponyfill/file',
-                FileReaderSync: '@ssttevee/blob-ponyfill/filereadersync',
-            },
-        }),
     ],
 };

--- a/example/ponyfill/package.json
+++ b/example/ponyfill/package.json
@@ -6,7 +6,6 @@
   },
   "devDependencies": {
     "@ssttevee/cfw-formdata-polyfill": "^0.1.0",
-    "@ssttevee/blob-ponyfill": "^0.1.0",
     "rollup": "^1.20.3",
     "rollup-plugin-inject": "^3.0.1",
     "rollup-plugin-node-resolve": "^5.2.0"

--- a/example/ponyfill/rollup.config.js
+++ b/example/ponyfill/rollup.config.js
@@ -10,12 +10,5 @@ module.exports = {
     plugins: [
         /* remove this */ { resolveId: (source) => source === '@ssttevee/cfw-formdata-polyfill/ponyfill' ? { id: require.resolve('../../ponyfill.js') } : undefined },
         resolve(),
-        inject({
-            modules: {
-                Blob: '@ssttevee/blob-ponyfill/blob',
-                File: '@ssttevee/blob-ponyfill/file',
-                FileReaderSync: '@ssttevee/blob-ponyfill/filereadersync',
-            },
-        }),
     ],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,63 @@
 {
   "name": "@ssttevee/cfw-formdata-polyfill",
   "version": "0.2.1",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
-  "dependencies": {
-    "@ssttevee/blob-ponyfill": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@ssttevee/blob-ponyfill/-/blob-ponyfill-0.1.0.tgz",
-      "integrity": "sha512-JqjpKtbwYukrS24Vk/W4OfHeTWEssnggSUksZZGmCNmxrpwDP3d6BwUcUtOruazmdNp9fB2SXWophjSGZzLd7g==",
-      "requires": {
+  "packages": {
+    "": {
+      "name": "@ssttevee/cfw-formdata-polyfill",
+      "version": "0.2.1",
+      "license": "MIT",
+      "dependencies": {
+        "@ssttevee/multipart-parser": "^0.1.6",
+        "@ssttevee/u8-utils": "^0.1.3"
+      },
+      "devDependencies": {
+        "typescript": "^3.5.3"
+      }
+    },
+    "node_modules/@ssttevee/multipart-parser": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@ssttevee/multipart-parser/-/multipart-parser-0.1.6.tgz",
+      "integrity": "sha512-UYsSZzxSKB7SFcgfE6wGeng4VR4/rC33zoWxtME4deirIztP/XPUBbX+lbLqV1+YdlKzmow4a4K1VfMB1DH00Q==",
+      "dependencies": {
+        "@ssttevee/streamsearch": "^0.1.3",
         "@ssttevee/u8-utils": "^0.1.3"
       }
     },
-    "@ssttevee/formdata-ponyfill": {
+    "node_modules/@ssttevee/streamsearch": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@ssttevee/formdata-ponyfill/-/formdata-ponyfill-0.1.4.tgz",
-      "integrity": "sha512-8GeH2CmdUEqFO68I4XDjqG6z2QNCYfaYnqJ4U+RoQZsM6UXVyudjIUHaF1LLTcNFggyQvE5gUg5wvFZluYBWMw=="
+      "resolved": "https://registry.npmjs.org/@ssttevee/streamsearch/-/streamsearch-0.1.4.tgz",
+      "integrity": "sha512-9yMRfhL/01h201Zuv65ly43NUpNy6wVdu9zT35bvmc7ct4OZCl5DLdfc7gzZB9teG6YuP0/GmlnuXtMgmA5axg==",
+      "dependencies": {
+        "@ssttevee/u8-utils": "^0.1.4"
+      }
     },
+    "node_modules/@ssttevee/streamsearch/node_modules/@ssttevee/u8-utils": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@ssttevee/u8-utils/-/u8-utils-0.1.4.tgz",
+      "integrity": "sha512-CqnrqVpq/PAp0K+H1KfRHwCZlNzqWPM080Ps33UHHe2QbGURHNBZdlK2ycNJRNHkroMtkCyabrjWF1UsFjOrEw=="
+    },
+    "node_modules/@ssttevee/u8-utils": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@ssttevee/u8-utils/-/u8-utils-0.1.3.tgz",
+      "integrity": "sha512-XX1JMEmKtxL7W3u9ZTZRkYVEk9/vhGD0DCJ0GHO15m+nO0PeUxcvLuGF3Y7w71DU2NYtxVWg+QOkcXqwbru2VA=="
+    },
+    "node_modules/typescript": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    }
+  },
+  "dependencies": {
     "@ssttevee/multipart-parser": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/@ssttevee/multipart-parser/-/multipart-parser-0.1.6.tgz",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,6 @@
   "author": "ssttevee",
   "license": "MIT",
   "dependencies": {
-    "@ssttevee/blob-ponyfill": "^0.1.0",
-    "@ssttevee/formdata-ponyfill": "^0.1.4",
     "@ssttevee/multipart-parser": "^0.1.6",
     "@ssttevee/u8-utils": "^0.1.3"
   },

--- a/src/ponyfill.ts
+++ b/src/ponyfill.ts
@@ -1,5 +1,3 @@
-import Blob from '@ssttevee/blob-ponyfill/blob';
-import FormData from '@ssttevee/formdata-ponyfill';
 import { parseMultipart } from '@ssttevee/multipart-parser';
 import { arrayToString } from '@ssttevee/u8-utils';
 


### PR DESCRIPTION
I have updated the polyfill to use CFW's new Blob and File support in FormData. The polyfill is still needed to fix FormData returning strings instead of File objects. With these changes you can also create requests with FormData containing files.

closes #2 